### PR TITLE
update AmountPercentage to omitempty

### DIFF
--- a/trade_type.go
+++ b/trade_type.go
@@ -348,7 +348,7 @@ type RoyaltyParameter struct {
 	TransOut         string  `json:"trans_out"`         // 可选 分账支出方账户，类型为userId，本参数为要分账的支付宝账号对应的支付宝唯一用户号。以2088开头的纯16位数字。
 	TransIn          string  `json:"trans_in"`          // 可选 分账收入方账户，类型为userId，本参数为要分账的支付宝账号对应的支付宝唯一用户号。以2088开头的纯16位数字。
 	Amount           float64 `json:"amount"`            // 可选 分账的金额，单位为元
-	AmountPercentage float64 `json:"amount_percentage"` // 可选 分账信息中分账百分比。取值范围为大于0，少于或等于100的整数。
+	AmountPercentage float64 `json:"amount_percentage,omitempty"` // 可选 分账信息中分账百分比。取值范围为大于0，少于或等于100的整数。
 	Desc             string  `json:"desc"`              // 可选 分账描述
 }
 


### PR DESCRIPTION
根据官方说明，https://openclub.alipay.com/read.php?tid=11504&fid=56
```
1.amount_percentage分账百分比指的是分出金额占该笔交易的百分比，目前只支持传入0和100不支持其他值，建议直接使用amount参数，分出多少传入多少金额。两个同时传入以amount_percentage为准。
```
由于struct的默认值，在只传Amount的情况下，生成的json中还是会包含amount_percentage的默认值，所以需要修改成omitempty