### PR TITLE
fix doRequest func's error return

### DIFF
--- a/alipay.go
+++ b/alipay.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -124,13 +125,15 @@ func (this *AliPay) doRequest(method string, param AliPayParam, results interfac
 		} else if errorIndex > 0 {
 			content, sign = parserJSONSource(dataStr, k_ERROR_RESPONSE, errorIndex)
 		} else {
-			return nil
+			return errors.New("no sign content found")
 		}
 
 		if sign != "" {
 			if ok, err := verifyData([]byte(content), this.SignType, sign, this.AliPayPublicKey); ok == false {
 				return err
 			}
+		} else {
+			return errors.New("no sign content found")
 		}
 	}
 
@@ -139,7 +142,11 @@ func (this *AliPay) doRequest(method string, param AliPayParam, results interfac
 		return err
 	}
 
-	return err
+	if results == nil {
+		return errors.New("results is nil")
+	}
+
+	return nil
 }
 
 func (this *AliPay) DoRequest(method string, param AliPayParam, results interface{}) (err error) {


### PR DESCRIPTION
doRequest 返回值err为nil时 results永远有值，防止调用方panic

之前代码的隐患举例：
result, err := client.TradePay(param)
if err != nil {
    return err
}

// 虽然上面判断了err,但是这里不保证result不为nil, 那么下面就有可能会panic
fmt.Println(result.AliPayTradePay.Code)
