### PR TITLE
修复verifySign函数

### DIFF
--- a/alipay.go
+++ b/alipay.go
@@ -233,23 +233,20 @@ func verifySign(data url.Values, key *rsa.PublicKey) (ok bool, err error) {
 	signType := data.Get("sign_type")
 
 	var keys = make([]string, 0, 0)
-	for key, value := range data {
+	for key := range data {
 		if key == "sign" || key == "sign_type" {
 			continue
 		}
-		if len(value) > 0 {
-			keys = append(keys, key)
-		}
+		keys = append(keys, key)
 	}
 
 	sort.Strings(keys)
 
 	var pList = make([]string, 0, 0)
 	for _, key := range keys {
-		var value = strings.TrimSpace(data.Get(key))
-		if len(value) > 0 {
-			pList = append(pList, key+"="+value)
-		}
+		// 此处忠实于支付宝返回参数，文档中并未提及value两边去除空格，以及空value的处理
+		// 实际遇到的问题是 标题后带空格被trim后验签错误
+		pList = append(pList, key+"="+data.Get(key))
 	}
 	var s = strings.Join(pList, "&")
 


### PR DESCRIPTION
遇到的问题是，支付宝回调返回的活动名称后带有空格，例："foobar "，被trim掉以后验签失败。同时支付宝文档也未提及去除空value的参数，文档原文：在通知返回参数列表中，除去 sign、sign_type 两个参数外，凡是通知返回回来的参数皆是待验签的参数（https://docs.open.alipay.com/204/105301/）。