### PR TITLE
增加客户端登录的参数签名功能

### DIFF
--- a/authorize_test.go
+++ b/authorize_test.go
@@ -1,8 +1,9 @@
 package alipay_test
 
 import (
-	"github.com/smartwalle/alipay/v3"
 	"testing"
+
+	"github.com/smartwalle/alipay/v3"
 )
 
 func TestClient_PublicAppAuthorize(t *testing.T) {
@@ -59,4 +60,20 @@ func TestClient_OpenAuthTokenApp(t *testing.T) {
 		t.Fatal(rsp.Content.Msg, rsp.Content.SubMsg)
 	}
 	t.Log(rsp.Content.AppAuthToken, rsp.Content.UserId)
+}
+
+func TestClient_SignLoginAuth(t *testing.T) {
+	t.Log("========== SignLoginAuth ==========")
+	var p = alipay.LoginOauthInfo{}
+	p.Pid = "2088123456789012"
+	p.TargetID = "kkkkk091125"
+	p.AuthType = "AUTHACCOUNT"
+	result, err := client.SignLoginAuth(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == "" {
+		t.Fatal(err)
+	}
+	t.Log(result)
 }

--- a/authorize_type.go
+++ b/authorize_type.go
@@ -135,3 +135,28 @@ type OpenAuthTokenAppRsp struct {
 	} `json:"alipay_open_auth_token_app_response"`
 	Sign string `json:"sign"`
 }
+
+// --------------------------------------------------------------------------------
+// https://docs.open.alipay.com/218/105327/
+type LoginOauthInfo struct {
+	Pid      string `json:"pid"`
+	TargetID string `json:"target_id"`
+	AuthType string `json:"auth_type"`
+}
+
+func (this LoginOauthInfo) APIName() string {
+	return "alipay.open.auth.sdk.code.get"
+}
+
+func (this LoginOauthInfo) Params() map[string]string {
+	var m = make(map[string]string)
+	m["apiname"] = "com.alipay.account.auth"
+	m["app_name"] = "mc"
+	m["biz_type"] = "openservice"
+	m["pid"] = this.Pid
+	m["product_id"] = "APP_FAST_LOGIN"
+	m["scope"] = "kuaijie"
+	m["target_id"] = this.TargetID
+	m["auth_type"] = this.AuthType
+	return m
+}


### PR DESCRIPTION
客户端使用支付宝做登录时，需向 alipay sdk 请求 authcode。
但请求的参数需要用私钥签名，需要在服务端增加这个功能