### PR TITLE
App支付增加订单商品明细字段

### DIFF
--- a/trade_type.go
+++ b/trade_type.go
@@ -477,7 +477,8 @@ func (this *TradePayRsp) IsSuccess() bool {
 // TradeAppPay App支付接口请求参数 https://docs.open.alipay.com/api_1/alipay.trade.app.pay/
 type TradeAppPay struct {
 	Trade
-	TimeExpire string `json:"time_expire,omitempty"` // 绝对超时时间，格式为yyyy-MM-dd HH:mm。
+	TimeExpire  string         `json:"time_expire,omitempty"`  // 绝对超时时间，格式为yyyy-MM-dd HH:mm。
+	GoodsDetail []*GoodsDetail `json:"goods_detail,omitempty"` // 订单包含的商品列表信息，Json格式，详见商品明细说明
 }
 
 func (this TradeAppPay) APIName() string {


### PR DESCRIPTION
根据文档，https://opendocs.alipay.com/apis/api_1/alipay.trade.app.pay，这是一个可选的字段，为了和手机网站支付、电脑网站支付一致，所以加上这个字段