### PR TITLE
Update trade_type.go

### DIFF
--- a/trade_type.go
+++ b/trade_type.go
@@ -28,6 +28,7 @@ type Trade struct {
 	StoreId          string `json:"store_id,omitempty"`          // 商户门店编号。该参数用于请求参数中以区分各门店，非必传项。
 	SubMerchant      string `json:"sub_merchant,omitempty"`      // 间连受理商户信息体，当前只对特殊银行机构特定场景下使用此字段
 	TimeoutExpress   string `json:"timeout_express,omitempty"`   // 该笔订单允许的最晚付款时间，逾期将关闭交易。取值范围：1m～15d。m-分钟，h-小时，d-天，1c-当天（1c-当天的情况下，无论交易何时创建，都在0点关闭）。 该参数数值不接受小数点， 如 1.5h，可转换为 90m。
+	TimeExpire       string `json:"time_expire,omitempty"`       // 该笔订单绝对超时时间，格式为yyyy-MM-dd HH:mm:ss
 }
 
 // TradePagePay 统一收单下单并支付页面接口请求参数 https://docs.open.alipay.com/api_1/alipay.trade.app.pay


### PR DESCRIPTION
添加time_expire订单绝对超时时间，在与TimeoutExpress时间作用不同，该值传入可控制交易链接用户打开时是否可用