### PR TITLE
修改FundAuthOrderFreeze 的APIName错误的问题

### DIFF
--- a/fund_type.go
+++ b/fund_type.go
@@ -149,7 +149,7 @@ type FundAuthOrderFreeze struct {
 }
 
 func (this FundAuthOrderFreeze) APIName() string {
-	return "alipay.fund.auth.order.voucher.create"
+	return "alipay.fund.auth.order.app.freeze"
 }
 
 func (this FundAuthOrderFreeze) Params() map[string]string {


### PR DESCRIPTION
FundAuthOrderFreeze的APIName 应该返回 alipay.fund.auth.order.app.freeze