### PR TITLE
fix 支付并签约提示商户协议不存在:alipay.trade.app.pay的agreement_sign_params缺少参数

### DIFF
--- a/trade_type.go
+++ b/trade_type.go
@@ -40,6 +40,7 @@ type Trade struct {
 }
 
 type SignParams struct {
+	Product             string             `json:"product"`                      // 必选 商家和支付宝签约的产品码。 商家扣款产品传入固定值：GENERAL_WITHHOLDING
 	PersonalProductCode string             `json:"personal_product_code"`        // 必选 个人签约产品码，商户和支付宝签约时确定。
 	SignScene           string             `json:"sign_scene"`                   // 必选 协议签约场景，商户和支付宝签约时确定，商户可咨询技术支持。
 	ExternalAgreementNo string             `json:"external_agreement_no"`        // 可选 商户签约号，代扣协议中标示用户的唯一签约号（确保在商户系统中唯一）。 格式规则：支持大写小写字母和数字，最长32位。 商户系统按需传入，如果同一用户在同一产品码、同一签约场景下，签订了多份代扣协议，那么需要指定并传入该值。


### PR DESCRIPTION
支付并签约的场景，agreement_sign_params里面还有一个product_code字段，必填，商家扣款产品传入固定值GENERAL_WITHHOLDING，否则会报“商户协议不存在”的报错。
![83B120FE-7423-4918-B3CD-CDAAB5250EDA](https://github.com/smartwalle/alipay/assets/22984307/89d8ee49-f645-4995-b03f-778d77007624)
