### PR TITLE
add OpBuyerOpenId

### DIFF
--- a/trade_type.go
+++ b/trade_type.go
@@ -432,6 +432,7 @@ type TradeCreate struct {
 	BuyerId            string             `json:"buyer_id"`            // 买家支付宝用户ID。 2088开头的16位纯数字，小程序场景下获取用户ID请参考：用户授权; 其它场景下获取用户ID请参考：网页授权获取用户信息; 注：交易的买家与卖家不能相同。
 	BuyerOpenId        string             `json:"buyer_open_id"`       // 新版接口无法获取user_id, 这里只能传递openid值
 	OpAppId            string             `json:"op_app_id,omitempty"` // 小程序支付中，商户实际经营主体的小程序应用的appid, 注意事项:商户需要先在产品管理中心绑定该小程序appid，否则下单会失败
+	OpBuyerOpenId      string             `json:"op_buyer_open_id,omitempty"` // 当传入的 op_app_id 与发起调用的 APPID 不一致时使用，传 op_buyer_open_id 替换 buyer_open_id
 	GoodsDetail        []*GoodsDetailItem `json:"goods_detail,omitempty"`
 	OperatorId         string             `json:"operator_id"`
 	TerminalId         string             `json:"terminal_id"`


### PR DESCRIPTION
当传入的 op_app_id 与发起调用的 APPID 不一致时使用，传 op_buyer_open_id 替换 buyer_open_id