### PR TITLE
feat: add GBK charset decoding support for callback notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,39 @@ alipay.ACKNotification(writer)
 })
 ```
 
+#### 处理 GBK 编码的通知
+
+支付宝异步通知的 Content-Type 可能是 `charset=GBK`，当通知中包含中文字段时（如商品标题、用户昵称等），这些字段会是 GBK 编码。
+
+**重要：不要在调用 SDK 前对请求体做任何字符集转换，否则会导致验签失败。**
+
+如果需要正确处理 GBK 编码的中文字段，请使用 `GetTradeNotificationWithCharset` 方法，它会根据 HTTP 请求头 Content-Type 中的 charset 参数判断编码格式，在验签通过后自动将 GBK 编码的字段转换为 UTF-8：
+
+```go
+http.HandleFunc("/notify", func (writer http.ResponseWriter, request *http.Request) {
+// GetTradeNotificationWithCharset 会根据 Content-Type header 中的 charset 自动解码 GBK
+var noti, err = client.GetTradeNotificationWithCharset(request)
+if err != nil {
+// 错误处理
+fmt.Println(err)
+return
+}
+// 此时 noti.Subject、noti.Body 等中文字段已经是 UTF-8 编码
+// 业务处理
+alipay.ACKNotification(writer)
+})
+```
+
+如果你已经解析了 Form，也可以直接使用 `DecodeNotificationWithCharset` 方法并传入 charset：
+
+```go
+request.ParseForm()
+charset := parseCharsetFromHeader(request.Header.Get("Content-Type")) // 自行解析 charset
+var noti, err = client.DecodeNotificationWithCharset(request.Form, charset)
+```
+
+会自动解码的字段包括：`Subject`、`Body`、`BuyerLogonId`、`PassbackParams`、`RefundReason`。
+
 #### 支持 RSA2 签名及验证
 
 采用 RSA2 签名，不再提供 RSA 的支持。

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,13 @@
 module github.com/smartwalle/alipay/v3
 
-go 1.18
+go 1.24.0
+
+toolchain go1.24.5
 
 require (
 	github.com/smartwalle/ncrypto v1.0.4
 	github.com/smartwalle/ngx v1.0.12
 	github.com/smartwalle/nsign v1.0.9
 )
+
+require golang.org/x/text v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
 github.com/smartwalle/ncrypto v1.0.4 h1:P2rqQxDepJwgeO5ShoC+wGcK2wNJDmcdBOWAksuIgx8=
 github.com/smartwalle/ncrypto v1.0.4/go.mod h1:Dwlp6sfeNaPMnOxMNayMTacvC5JGEVln3CVdiVDgbBk=
-github.com/smartwalle/ngx v1.0.9 h1:pUXDvWRZJIHVrCKA1uZ15YwNti+5P4GuJGbpJ4WvpMw=
-github.com/smartwalle/ngx v1.0.9/go.mod h1:mx/nz2Pk5j+RBs7t6u6k22MPiBG/8CtOMpCnALIG8Y0=
-github.com/smartwalle/ngx v1.0.11 h1:cC+4WNKEUDf3wr7vW/GrbL+Cp2AJAk5svckPvQ3led8=
-github.com/smartwalle/ngx v1.0.11/go.mod h1:mx/nz2Pk5j+RBs7t6u6k22MPiBG/8CtOMpCnALIG8Y0=
 github.com/smartwalle/ngx v1.0.12 h1:jcoCyu/0HtQ1y/gbiSLzqOUZcHnVLlKOmm0awRF7Mcg=
 github.com/smartwalle/ngx v1.0.12/go.mod h1:mx/nz2Pk5j+RBs7t6u6k22MPiBG/8CtOMpCnALIG8Y0=
 github.com/smartwalle/nsign v1.0.9 h1:8poAgG7zBd8HkZy9RQDwasC6XZvJpDGQWSjzL2FZL6E=
 github.com/smartwalle/nsign v1.0.9/go.mod h1:eY6I4CJlyNdVMP+t6z1H6Jpd4m5/V+8xi44ufSTxXgc=
+golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
+golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=

--- a/notify.go
+++ b/notify.go
@@ -6,6 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/transform"
 )
 
 var (
@@ -99,6 +103,63 @@ func (c *Client) DecodeNotification(values url.Values) (notification *Notificati
 	notification.BankAckTime = values.Get("bank_ack_time")
 	notification.SendBackFee = values.Get("send_back_fee")
 	return notification, err
+}
+
+// GetTradeNotificationWithCharset parses notification and decodes GBK fields to UTF-8.
+// It extracts charset from Content-Type header and converts GBK-encoded fields after signature verification.
+func (c *Client) GetTradeNotificationWithCharset(req *http.Request) (notification *Notification, err error) {
+	if req == nil {
+		return nil, errors.New("request is nil")
+	}
+	if err = req.ParseForm(); err != nil {
+		return nil, err
+	}
+	charset := parseCharsetFromContentType(req.Header.Get("Content-Type"))
+	return c.DecodeNotificationWithCharset(req.Form, charset)
+}
+
+// DecodeNotificationWithCharset decodes notification and converts GBK fields to UTF-8 based on charset.
+// If charset is GBK/GB2312/GB18030, it converts Subject, Body, BuyerLogonId, PassbackParams, RefundReason.
+func (c *Client) DecodeNotificationWithCharset(values url.Values, charset string) (notification *Notification, err error) {
+	notification, err = c.DecodeNotification(values)
+	if err != nil {
+		return nil, err
+	}
+
+	charset = strings.ToUpper(charset)
+	if charset == "GBK" || charset == "GB2312" || charset == "GB18030" {
+		notification.Subject = decodeGBK(notification.Subject)
+		notification.Body = decodeGBK(notification.Body)
+		notification.BuyerLogonId = decodeGBK(notification.BuyerLogonId)
+		notification.PassbackParams = decodeGBK(notification.PassbackParams)
+		notification.RefundReason = decodeGBK(notification.RefundReason)
+	}
+
+	return notification, nil
+}
+
+// parseCharsetFromContentType extracts charset from Content-Type header.
+func parseCharsetFromContentType(contentType string) string {
+	for _, part := range strings.Split(contentType, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(strings.ToLower(part), "charset=") {
+			return strings.TrimPrefix(part, "charset=")
+		}
+	}
+	return ""
+}
+
+// decodeGBK converts GBK-encoded string to UTF-8.
+func decodeGBK(s string) string {
+	if s == "" {
+		return s
+	}
+	reader := transform.NewReader(strings.NewReader(s), simplifiedchinese.GBK.NewDecoder())
+	result, err := io.ReadAll(reader)
+	if err != nil {
+		return s
+	}
+	return string(result)
 }
 
 // AckNotification

--- a/notify_test.go
+++ b/notify_test.go
@@ -1,0 +1,136 @@
+package alipay
+
+import (
+	"testing"
+)
+
+func TestDecodeGBK(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "ascii only",
+			input:    "hello world 123",
+			expected: "hello world 123",
+		},
+		{
+			name:     "GBK encoded Chinese - 树",
+			input:    "\xca\xf7", // GBK encoding of "树"
+			expected: "树",
+		},
+		{
+			name:     "GBK encoded Chinese - 中国",
+			input:    "\xd6\xd0\xb9\xfa", // GBK encoding of "中国"
+			expected: "中国",
+		},
+		{
+			name:     "mixed ascii and GBK",
+			input:    "test\xca\xf7123", // "test树123"
+			expected: "test树123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := decodeGBK(tt.input)
+			if result != tt.expected {
+				t.Errorf("decodeGBK(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDecodeNotificationWithCharset_GBK(t *testing.T) {
+	// Test the decodeGBK function with URL-decoded values
+	// In real scenario, url.ParseQuery will decode %CA%F7 to \xca\xf7 (raw bytes)
+
+	// URL decode simulation - %CA%F7 becomes raw bytes \xca\xf7
+	rawGBK := "\xca\xf7"
+	decoded := decodeGBK(rawGBK)
+
+	if decoded != "树" {
+		t.Errorf("Expected '树', got %q", decoded)
+	}
+}
+
+func TestParseCharsetFromContentType(t *testing.T) {
+	tests := []struct {
+		contentType string
+		expected    string
+	}{
+		{"application/x-www-form-urlencoded; charset=GBK", "GBK"},
+		{"application/x-www-form-urlencoded; charset=gbk", "gbk"},
+		{"application/x-www-form-urlencoded; charset=UTF-8", "UTF-8"},
+		{"application/x-www-form-urlencoded;charset=GBK", "GBK"},
+		{"application/x-www-form-urlencoded", ""},
+		{"text/html; charset=GB2312; boundary=something", "GB2312"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.contentType, func(t *testing.T) {
+			result := parseCharsetFromContentType(tt.contentType)
+			if result != tt.expected {
+				t.Errorf("parseCharsetFromContentType(%q) = %q, want %q", tt.contentType, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDecodeNotificationWithCharset_UTF8(t *testing.T) {
+	// When charset is UTF-8, the data should remain unchanged
+	utf8String := "中文测试"
+	result := decodeGBK(utf8String)
+
+	// Note: decodeGBK will try to decode UTF-8 as GBK, which may produce garbled text
+	// This is expected behavior - the DecodeNotificationWithCharset method
+	// only calls decodeGBK when charset is GBK/GB2312/GB18030
+
+	// The important thing is that DecodeNotificationWithCharset checks charset first
+	// and only decodes when necessary
+	t.Logf("UTF-8 string through GBK decoder: %q -> %q", utf8String, result)
+}
+
+func TestCharsetCheck(t *testing.T) {
+	// Test that charset checking works for various cases
+	charsets := []struct {
+		input    string
+		expected bool
+	}{
+		{"GBK", true},
+		{"gbk", true},
+		{"GB2312", true},
+		{"gb2312", true},
+		{"GB18030", true},
+		{"gb18030", true},
+		{"UTF-8", false},
+		{"utf-8", false},
+		{"UTF8", false},
+		{"", false},
+	}
+
+	for _, tc := range charsets {
+		t.Run(tc.input, func(t *testing.T) {
+			// Simulate the check in DecodeNotificationWithCharset
+			upper := ""
+			for _, c := range tc.input {
+				if c >= 'a' && c <= 'z' {
+					upper += string(c - 32)
+				} else {
+					upper += string(c)
+				}
+			}
+			isGBK := upper == "GBK" || upper == "GB2312" || upper == "GB18030"
+			if isGBK != tc.expected {
+				t.Errorf("charset %q: got isGBK=%v, want %v", tc.input, isGBK, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add GetTradeNotificationWithCharset and DecodeNotificationWithCharset methods to automatically decode GBK-encoded fields (Subject, Body, BuyerLogonId, PassbackParams, RefundReason) to UTF-8 after signature verification.

The charset is extracted from the Content-Type header to determine if GBK decoding is needed.

Here are some talk with alipay
<img width="367" height="889" alt="image" src="https://github.com/user-attachments/assets/7be6e692-c855-4b71-a254-a5ad8d61347e" />
<img width="349" height="592" alt="image" src="https://github.com/user-attachments/assets/5bb23faa-3488-4532-af6d-0c8308fba7b8" />
