### PR TITLE
fix: 兼容 GBK 编码的同步响应与异步通知

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ p.NotifyURL = "http://xxx/return"
 http.HandleFunc("/notify", func (writer http.ResponseWriter, request *http.Request) {
 request.ParseForm()
 
-// DecodeNotification 内部已调用 VerifySign 方法验证签名
-var noti, err = client.DecodeNotification(request.Form)
+// DecodeNotification 内部已调用 VerifySign 方法验证签名。
+// 如果已签名的 charset 参数为 GBK/GB2312/GB18030，会在验签成功后
+// 自动将通知字段转换为 UTF-8。
+var noti, err = client.DecodeNotification(request.Context(), request.Form)
 if err != nil {
 // 错误处理
 fmt.Println(err)
@@ -149,6 +151,19 @@ return
 alipay.ACKNotification(writer)
 })
 ```
+
+如果通知表单中没有 `charset` 参数，但 HTTP `Content-Type` 明确声明了
+GBK 编码，可以在解析请求头后显式传入：
+
+```go
+_, params, _ := mime.ParseMediaType(request.Header.Get("Content-Type"))
+var noti, err = client.DecodeNotificationWithCharset(
+request.Context(), request.Form, params["charset"],
+)
+```
+
+字符集转换不会修改原始 `request.Form`；SDK 始终先使用原始字节验签，
+仅在验签成功后转换返回的 `Notification` 字段。
 
 #### 支持 RSA2 签名及验证
 
@@ -471,4 +486,3 @@ if err != nil {
 ## License
 
 This project is licensed under the MIT License.
-

--- a/alipay.go
+++ b/alipay.go
@@ -444,7 +444,7 @@ func (c *Client) decode(ctx context.Context, data []byte, bizFieldName string, n
 	if len(bizBytes) == 0 {
 		if len(errBytes) > 0 {
 			var rErr *Error
-			if err = json.Unmarshal(errBytes, &rErr); err != nil {
+			if err = unmarshalResponseJSON(errBytes, &rErr); err != nil {
 				return err
 			}
 			return rErr
@@ -467,7 +467,7 @@ func (c *Client) decode(ctx context.Context, data []byte, bizFieldName string, n
 		if len(signBytes) == 0 {
 			// 没有签名数据，返回的内容一般为错误信息
 			var rErr *Error
-			if err = json.Unmarshal(plaintext, &rErr); err != nil {
+			if err = unmarshalResponseJSON(plaintext, &rErr); err != nil {
 				return err
 			}
 			return rErr
@@ -479,7 +479,7 @@ func (c *Client) decode(ctx context.Context, data []byte, bizFieldName string, n
 		}
 	}
 
-	if err = json.Unmarshal(plaintext, dest); err != nil {
+	if err = unmarshalResponseJSON(plaintext, dest); err != nil {
 		return err
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/smartwalle/ncrypto v1.0.4
 	github.com/smartwalle/ngx v1.1.1
 	github.com/smartwalle/nsign v1.0.9
+	golang.org/x/text v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,5 @@ github.com/smartwalle/ngx v1.1.1 h1:71qpkunFB36Q4QoR1KOPtH1MhsJPZalpj4p6iudkT3Y=
 github.com/smartwalle/ngx v1.1.1/go.mod h1:mx/nz2Pk5j+RBs7t6u6k22MPiBG/8CtOMpCnALIG8Y0=
 github.com/smartwalle/nsign v1.0.9 h1:8poAgG7zBd8HkZy9RQDwasC6XZvJpDGQWSjzL2FZL6E=
 github.com/smartwalle/nsign v1.0.9/go.mod h1:eY6I4CJlyNdVMP+t6z1H6Jpd4m5/V+8xi44ufSTxXgc=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=

--- a/notify.go
+++ b/notify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 )
@@ -39,7 +40,7 @@ func (c *Client) NotifyVerify(ctx context.Context, partnerId, notifyId string) b
 }
 
 // GetTradeNotification
-// Deprecated: use DecodeNotification instead.
+// Deprecated: use DecodeNotification or DecodeNotificationWithCharset instead.
 func (c *Client) GetTradeNotification(req *http.Request) (notification *Notification, err error) {
 	if req == nil {
 		return nil, errors.New("request 参数不能为空")
@@ -47,11 +48,29 @@ func (c *Client) GetTradeNotification(req *http.Request) (notification *Notifica
 	if err = req.ParseForm(); err != nil {
 		return nil, err
 	}
-	return c.DecodeNotification(context.Background(), req.Form)
+	return c.DecodeNotificationWithCharset(
+		context.Background(),
+		req.Form,
+		charsetFromContentType(req.Header.Get("Content-Type")),
+	)
 }
 
 func (c *Client) DecodeNotification(ctx context.Context, values url.Values) (notification *Notification, err error) {
+	return c.DecodeNotificationWithCharset(ctx, values, "")
+}
+
+// DecodeNotificationWithCharset 解析并验签支付宝异步通知，并按声明的字符集
+// 在验签成功后将通知字段转换为 UTF-8。values 中已签名的 charset
+// 优先于显式传入的 charset，避免未签名的 HTTP 请求头改变解码方式。
+func (c *Client) DecodeNotificationWithCharset(ctx context.Context, values url.Values, charset string) (notification *Notification, err error) {
 	if err = c.VerifySign(ctx, values); err != nil {
+		return nil, err
+	}
+
+	if signedCharset := values.Get("charset"); signedCharset != "" {
+		charset = signedCharset
+	}
+	if values, err = decodeNotificationValues(values, charset); err != nil {
 		return nil, err
 	}
 
@@ -100,6 +119,35 @@ func (c *Client) DecodeNotification(ctx context.Context, values url.Values) (not
 	notification.BankAckTime = values.Get("bank_ack_time")
 	notification.SendBackFee = values.Get("send_back_fee")
 	return notification, err
+}
+
+func decodeNotificationValues(values url.Values, charset string) (url.Values, error) {
+	decoder := decoderForCharset(charset)
+	if decoder == nil {
+		return values, nil
+	}
+
+	decodedValues := make(url.Values, len(values))
+	for key, valueList := range values {
+		decodedList := make([]string, len(valueList))
+		for index, value := range valueList {
+			decoded, err := decoder.Bytes([]byte(value))
+			if err != nil {
+				return nil, err
+			}
+			decodedList[index] = string(decoded)
+		}
+		decodedValues[key] = decodedList
+	}
+	return decodedValues, nil
+}
+
+func charsetFromContentType(contentType string) string {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ""
+	}
+	return params["charset"]
 }
 
 // AckNotification

--- a/notify_encoding_test.go
+++ b/notify_encoding_test.go
@@ -1,0 +1,196 @@
+package alipay
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/smartwalle/nsign"
+	"golang.org/x/text/encoding/simplifiedchinese"
+)
+
+type notificationVerifier struct {
+	t               *testing.T
+	expectedSubject string
+	expectedSign    []byte
+	called          bool
+}
+
+func (v *notificationVerifier) VerifyValues(values url.Values, signature []byte, _ ...nsign.SignOption) error {
+	v.called = true
+	if got := values.Get("subject"); got != v.expectedSubject {
+		v.t.Errorf("subject changed before signature verification\ngot:  %x\nwant: %x", []byte(got), []byte(v.expectedSubject))
+	}
+	if !bytes.Equal(signature, v.expectedSign) {
+		v.t.Errorf("signature = %x, want %x", signature, v.expectedSign)
+	}
+	return nil
+}
+
+func (v *notificationVerifier) VerifyBytes(_ []byte, _ []byte, _ ...nsign.SignOption) error {
+	v.t.Fatal("VerifyBytes should not be called")
+	return nil
+}
+
+func TestDecodeNotificationDecodesAllGBKValuesAfterVerification(t *testing.T) {
+	subject := string(encodeGBK(t, "测试商品"))
+	signature := []byte("notification-signature")
+	values := url.Values{
+		"charset":             {"GBK"},
+		"subject":             {subject},
+		"body":                {string(encodeGBK(t, "商品描述"))},
+		"buyer_logon_id":      {string(encodeGBK(t, "买家账号"))},
+		"refund_reason":       {string(encodeGBK(t, "退款原因"))},
+		"passback_params":     {string(encodeGBK(t, "回传参数"))},
+		"voucher_detail_list": {string(encodeGBK(t, `[{"name":"优惠券"}]`))},
+		"sign_type":           {"RSA2"},
+		"sign":                {base64.StdEncoding.EncodeToString(signature)},
+	}
+	verifier := &notificationVerifier{
+		t:               t,
+		expectedSubject: subject,
+		expectedSign:    signature,
+	}
+	client := notificationTestClient(verifier)
+
+	notification, err := client.DecodeNotification(context.Background(), values)
+	if err != nil {
+		t.Fatalf("DecodeNotification: %v", err)
+	}
+	if !verifier.called {
+		t.Fatal("notification signature was not verified")
+	}
+	if values.Get("subject") != subject {
+		t.Fatal("DecodeNotification modified the signed input values")
+	}
+	assertNotificationText(t, notification)
+}
+
+func TestDecodeNotificationWithCharsetSupportsGB18030(t *testing.T) {
+	subjectBytes, err := simplifiedchinese.GB18030.NewEncoder().Bytes([]byte("𠀀商品"))
+	if err != nil {
+		t.Fatalf("encode GB18030 fixture: %v", err)
+	}
+	signature := []byte("notification-signature")
+	values := url.Values{
+		"subject":   {string(subjectBytes)},
+		"sign_type": {"RSA2"},
+		"sign":      {base64.StdEncoding.EncodeToString(signature)},
+	}
+	verifier := &notificationVerifier{
+		t:               t,
+		expectedSubject: string(subjectBytes),
+		expectedSign:    signature,
+	}
+	client := notificationTestClient(verifier)
+
+	notification, err := client.DecodeNotificationWithCharset(context.Background(), values, "GB18030")
+	if err != nil {
+		t.Fatalf("DecodeNotificationWithCharset: %v", err)
+	}
+	if got, want := notification.Subject, "𠀀商品"; got != want {
+		t.Fatalf("Subject = %q, want %q", got, want)
+	}
+}
+
+func TestDecodeNotificationPrefersSignedCharset(t *testing.T) {
+	subject := string(encodeGBK(t, "测试商品"))
+	signature := []byte("notification-signature")
+	values := url.Values{
+		"charset":   {"GBK"},
+		"subject":   {subject},
+		"sign_type": {"RSA2"},
+		"sign":      {base64.StdEncoding.EncodeToString(signature)},
+	}
+	client := notificationTestClient(&notificationVerifier{
+		t:               t,
+		expectedSubject: subject,
+		expectedSign:    signature,
+	})
+
+	notification, err := client.DecodeNotificationWithCharset(context.Background(), values, "UTF-8")
+	if err != nil {
+		t.Fatalf("DecodeNotificationWithCharset: %v", err)
+	}
+	if got, want := notification.Subject, "测试商品"; got != want {
+		t.Fatalf("Subject = %q, want %q", got, want)
+	}
+}
+
+func TestGetTradeNotificationUsesContentTypeCharsetFallback(t *testing.T) {
+	subject := string(encodeGBK(t, "测试商品"))
+	signature := []byte("notification-signature")
+	values := url.Values{
+		"subject":   {subject},
+		"sign_type": {"RSA2"},
+		"sign":      {base64.StdEncoding.EncodeToString(signature)},
+	}
+	request := httptest.NewRequest("POST", "/notify", bytes.NewBufferString(values.Encode()))
+	request.Header.Set("Content-Type", `application/x-www-form-urlencoded; charset="GBK"`)
+	client := notificationTestClient(&notificationVerifier{
+		t:               t,
+		expectedSubject: subject,
+		expectedSign:    signature,
+	})
+
+	notification, err := client.GetTradeNotification(request)
+	if err != nil {
+		t.Fatalf("GetTradeNotification: %v", err)
+	}
+	if got, want := notification.Subject, "测试商品"; got != want {
+		t.Fatalf("Subject = %q, want %q", got, want)
+	}
+}
+
+func TestDecodeNotificationLeavesUTF8ValuesUnchanged(t *testing.T) {
+	signature := []byte("notification-signature")
+	values := url.Values{
+		"charset":   {"UTF-8"},
+		"subject":   {"测试商品"},
+		"sign_type": {"RSA2"},
+		"sign":      {base64.StdEncoding.EncodeToString(signature)},
+	}
+	client := notificationTestClient(&notificationVerifier{
+		t:               t,
+		expectedSubject: "测试商品",
+		expectedSign:    signature,
+	})
+
+	notification, err := client.DecodeNotification(context.Background(), values)
+	if err != nil {
+		t.Fatalf("DecodeNotification: %v", err)
+	}
+	if got, want := notification.Subject, "测试商品"; got != want {
+		t.Fatalf("Subject = %q, want %q", got, want)
+	}
+}
+
+func notificationTestClient(verifier Verifier) *Client {
+	return &Client{
+		aliCertSN: "test-cert",
+		verifiers: map[string]Verifier{"test-cert": verifier},
+	}
+}
+
+func assertNotificationText(t *testing.T, notification *Notification) {
+	t.Helper()
+	checks := map[string]struct {
+		got  string
+		want string
+	}{
+		"Subject":           {notification.Subject, "测试商品"},
+		"Body":              {notification.Body, "商品描述"},
+		"BuyerLogonId":      {notification.BuyerLogonId, "买家账号"},
+		"RefundReason":      {notification.RefundReason, "退款原因"},
+		"PassbackParams":    {notification.PassbackParams, "回传参数"},
+		"VoucherDetailList": {notification.VoucherDetailList, `[{"name":"优惠券"}]`},
+	}
+	for name, check := range checks {
+		if check.got != check.want {
+			t.Errorf("%s = %q, want %q", name, check.got, check.want)
+		}
+	}
+}

--- a/response_encoding.go
+++ b/response_encoding.go
@@ -1,0 +1,27 @@
+package alipay
+
+import (
+	"encoding/json"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+)
+
+// unmarshalResponseJSON 兼容支付宝偶发返回的 GBK 编码响应。
+//
+// SDK 请求声明的编码是 UTF-8，但部分业务错误响应的中文字段
+// 仍可能以 GBK 编码返回。encoding/json 会将 JSON 字符串中的非法
+// UTF-8 字节替换为 U+FFFD，从而丢失原始错误信息。
+//
+// 对于带签名的响应，调用方必须先使用原始字节完成验签，
+// 再调用本函数，避免转码改变待验签内容。
+func unmarshalResponseJSON(data []byte, dest interface{}) error {
+	if !utf8.Valid(data) {
+		decoded, err := simplifiedchinese.GBK.NewDecoder().Bytes(data)
+		if err != nil {
+			return err
+		}
+		data = decoded
+	}
+	return json.Unmarshal(data, dest)
+}

--- a/response_encoding.go
+++ b/response_encoding.go
@@ -2,8 +2,10 @@ package alipay
 
 import (
 	"encoding/json"
+	"strings"
 	"unicode/utf8"
 
+	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/simplifiedchinese"
 )
 
@@ -24,4 +26,15 @@ func unmarshalResponseJSON(data []byte, dest interface{}) error {
 		data = decoded
 	}
 	return json.Unmarshal(data, dest)
+}
+
+func decoderForCharset(charset string) *encoding.Decoder {
+	switch strings.ToLower(strings.TrimSpace(charset)) {
+	case "gbk", "gb2312":
+		return simplifiedchinese.GBK.NewDecoder()
+	case "gb18030":
+		return simplifiedchinese.GB18030.NewDecoder()
+	default:
+		return nil
+	}
 }

--- a/response_encoding_test.go
+++ b/response_encoding_test.go
@@ -1,0 +1,127 @@
+package alipay
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/smartwalle/nsign"
+	"golang.org/x/text/encoding/simplifiedchinese"
+)
+
+type recordingVerifier struct {
+	t            *testing.T
+	expectedData []byte
+	expectedSign []byte
+	called       bool
+}
+
+func (v *recordingVerifier) VerifyValues(_ url.Values, _ []byte, _ ...nsign.SignOption) error {
+	v.t.Fatal("VerifyValues should not be called")
+	return nil
+}
+
+func (v *recordingVerifier) VerifyBytes(data, signature []byte, _ ...nsign.SignOption) error {
+	v.called = true
+	if !bytes.Equal(data, v.expectedData) {
+		v.t.Errorf("verified data changed before signature verification\ngot:  %x\nwant: %x", data, v.expectedData)
+	}
+	if !bytes.Equal(signature, v.expectedSign) {
+		v.t.Errorf("signature = %x, want %x", signature, v.expectedSign)
+	}
+	return nil
+}
+
+func TestClientDecodeGBKResponseAfterVerifyingOriginalBytes(t *testing.T) {
+	biz := encodeGBK(t, `{"code":"20000","msg":"Service Currently Unavailable","sub_code":"aop.unknow-error","sub_msg":"系统繁忙"}`)
+	signature := []byte("test-signature")
+	envelope := append([]byte(`{"test_response":`), biz...)
+	envelope = append(envelope, []byte(`,"sign":"`+base64.StdEncoding.EncodeToString(signature)+`"}`)...)
+
+	verifier := &recordingVerifier{
+		t:            t,
+		expectedData: biz,
+		expectedSign: signature,
+	}
+	client := &Client{
+		aliCertSN: "test-cert",
+		verifiers: map[string]Verifier{"test-cert": verifier},
+	}
+	var received []byte
+	client.OnReceivedData(func(_ context.Context, method string, data []byte) {
+		if method != "test_response" {
+			t.Errorf("received method = %q, want test_response", method)
+		}
+		received = append([]byte(nil), data...)
+	})
+
+	var response BillDownloadURLQueryRsp
+	if err := client.decode(context.Background(), envelope, "test_response", true, &response); err != nil {
+		t.Fatalf("decode GBK response: %v", err)
+	}
+	if !verifier.called {
+		t.Fatal("response signature was not verified")
+	}
+	if !bytes.Equal(received, biz) {
+		t.Fatalf("received data changed\ngot:  %x\nwant: %x", received, biz)
+	}
+	if got, want := response.SubMsg, "系统繁忙"; got != want {
+		t.Fatalf("SubMsg = %q, want %q", got, want)
+	}
+}
+
+func TestClientDecodeGBKUnsignedBusinessError(t *testing.T) {
+	biz := encodeGBK(t, `{"code":"20000","msg":"Service Currently Unavailable","sub_code":"aop.unknow-error","sub_msg":"系统繁忙"}`)
+	envelope := append([]byte(`{"test_response":`), biz...)
+	envelope = append(envelope, '}')
+
+	client := &Client{}
+	var response BillDownloadURLQueryRsp
+	err := client.decode(context.Background(), envelope, "test_response", true, &response)
+	var responseErr *Error
+	if !errors.As(err, &responseErr) {
+		t.Fatalf("decode error = %v, want *Error", err)
+	}
+	if got, want := responseErr.SubMsg, "系统繁忙"; got != want {
+		t.Fatalf("SubMsg = %q, want %q", got, want)
+	}
+}
+
+func TestClientDecodeGBKTopLevelError(t *testing.T) {
+	errorResponse := encodeGBK(t, `{"code":"20000","msg":"Service Currently Unavailable","sub_code":"aop.unknow-error","sub_msg":"系统繁忙"}`)
+	envelope := append([]byte(`{"error_response":`), errorResponse...)
+	envelope = append(envelope, '}')
+
+	client := &Client{}
+	var response BillDownloadURLQueryRsp
+	err := client.decode(context.Background(), envelope, "test_response", true, &response)
+	var responseErr *Error
+	if !errors.As(err, &responseErr) {
+		t.Fatalf("decode error = %v, want *Error", err)
+	}
+	if got, want := responseErr.SubMsg, "系统繁忙"; got != want {
+		t.Fatalf("SubMsg = %q, want %q", got, want)
+	}
+}
+
+func TestUnmarshalResponseJSONLeavesUTF8Unchanged(t *testing.T) {
+	var response Error
+	if err := unmarshalResponseJSON([]byte(`{"sub_msg":"系统繁忙"}`), &response); err != nil {
+		t.Fatalf("unmarshal UTF-8 response: %v", err)
+	}
+	if got, want := response.SubMsg, "系统繁忙"; got != want {
+		t.Fatalf("SubMsg = %q, want %q", got, want)
+	}
+}
+
+func encodeGBK(t *testing.T, value string) []byte {
+	t.Helper()
+	encoded, err := simplifiedchinese.GBK.NewEncoder().Bytes([]byte(value))
+	if err != nil {
+		t.Fatalf("encode GBK fixture: %v", err)
+	}
+	return encoded
+}


### PR DESCRIPTION
## 背景

支付宝的同步 API 响应和异步通知都可能包含 GBK 编码的中文，但 SDK 目前会将这些字节直接当作 UTF-8 处理。

### 同步 API 响应

SDK 请求声明 `charset=utf-8`，但部分业务错误响应会偶发以 GBK 编码返回中文字段。例如：

```text
code=20000
msg=Service Currently Unavailable
sub_code=aop.unknow-error
sub_msg=系统繁忙
```

`sub_msg` 的原始字节实际是 GBK。当 SDK 直接使用 `encoding/json` 解析时，非法 UTF-8 字节会被替换成 `U+FFFD`，最终得到类似 `ϵͳ��æ` 的乱码，原始错误信息无法恢复。

### 异步通知

异步通知的表单字段可能按 `GBK` / `GB2312` / `GB18030` 编码传输。`url.ParseQuery` / `request.ParseForm` 会保留 URL 解码后的原始字节，因此验签可以正常完成，但返回的 `Notification` 中文字段会是乱码。

## 修复方式

### 同步响应

- 新增统一的响应 JSON 解析函数：
  - 合法 UTF-8 响应保持原样；
  - 非法 UTF-8 响应先按 GBK 解码，再进行 JSON 反序列化。
- 覆盖同步响应的三条解析路径：
  - 正常业务响应（包含业务失败码）；
  - 无签名的业务错误响应；
  - 顶层 `error_response`。
- 带签名响应始终先使用原始字节验签，只在验签成功后转码。
- `OnReceivedData` 仍保持现有语义，接收原始业务响应字节。

### 异步通知

- `DecodeNotification` 验签成功后，根据已签名的 `charset` 参数自动将通知字段转为 UTF-8。
- 新增 `DecodeNotificationWithCharset`，支持在表单没有 `charset` 时显式传入 HTTP `Content-Type` 声明的字符集。
- 已签名的表单 `charset` 优先于未签名的 HTTP 请求头，避免请求头改变解码方式。
- 同时支持 `GBK`、`GB2312` 和 `GB18030`。
- 验签始终使用原始 `url.Values`；转码在副本上进行，不修改调用方传入的已签名数据。
- 对全部通知表单值统一转码，不仅限于当前已知的几个中文字段。
- 兼容已有的 `GetTradeNotification`：当表单未声明 charset 时，会从 `Content-Type` 读取后备字符集。

## 测试

新增的纯单元测试覆盖：

- 带签名 GBK 同步响应：验证验签器收到的仍是完全一致的原始 GBK 字节；
- 无签名 GBK 业务错误和顶层 `error_response`；
- 正常 UTF-8 同步响应不受影响；
- GBK 异步通知在验签后转码，且原始 `url.Values` 不受修改；
- 全部通知字段（包含嵌套 JSON 字符串）的统一转码；
- GB18030 扩展字符；
- 已签名 charset 优先于显式传入的 charset；
- HTTP `Content-Type` charset 后备路径；
- UTF-8 异步通知不受影响。

```bash
go test -race -count=1 -run '^(TestClientDecodeGBKResponseAfterVerifyingOriginalBytes|TestClientDecodeGBKUnsignedBusinessError|TestClientDecodeGBKTopLevelError|TestUnmarshalResponseJSONLeavesUTF8Unchanged|TestDecodeNotification.*|TestGetTradeNotification.*)$' ./...
go test -run '^$' ./...
go vet ./...
GOTOOLCHAIN=go1.19.13 go test -run '^(TestClientDecodeGBKResponseAfterVerifyingOriginalBytes|TestClientDecodeGBKUnsignedBusinessError|TestClientDecodeGBKTopLevelError|TestUnmarshalResponseJSONLeavesUTF8Unchanged|TestDecodeNotification.*|TestGetTradeNotification.*)$' ./...
```

上述检查均已通过。仓库其余测试会直连支付宝沙箱并依赖有效的授权码、交易号等外部状态，因此未作为本 PR 的可重复单元测试门禁。

## 与 #248 的关系

异步通知部分参考并扩展了 #248 的问题分析与测试场景，感谢 @tc6-01 定位该问题。

本 PR 在同一套编码依赖上同时覆盖同步 JSON 响应与异步表单通知，并对异步路径增加了已签名 charset 优先级、所有字段统一转码、GB18030 扩展字符以及输入不可变性测试。
